### PR TITLE
CCH #109 - September 2017

### DIFF
--- a/2017.mdown
+++ b/2017.mdown
@@ -215,6 +215,16 @@ Theme - **Automation and Tooling**
 
 Realestate.com.au
 
+### Presentations
+
+- Gavan Chan [@gavanchan][gavanchan] - The Month That Was
+- Stew Gleadow - Automated Workflow
+- Jean-Étienne [@jeanetienne][jeanetienne] - Xcode 9 File Templates
+
+### Lightning Talks
+
+- Ben Deckys [@cocotutch][cocotouch] - Supporting iPhone X
+
 ### Meta
 
 Melbourne CocoaHeads Blog - [Upcoming Meetup Topics](https://www.melbournecocoaheads.com/updates/topics-for-cocoaheads-no-109-110-september-october-2017)
@@ -233,3 +243,6 @@ Theme - **ARKit**
 
 JTribe
 
+[cocotouch]: https://www.twitter.com/cocotouch
+[jeanetienne]: https://www.twitter.com/jeanetienne
+[gavanchan]: https://www.twitter.com/gavanchan


### PR DESCRIPTION
Updating a (sort of) living doc, this change provides the details of the September 2017 Cocoaheads meetup.

This change follows the convention for links to presenters' Twitter profiles as proposed in #24 (Twitter Links in the 2017 history). Changes mandated through the process of that review may affect the direction of this review, and so, review of #24 prior to this may be beneficial.